### PR TITLE
Small fixes from local testing

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: fishtown-analytics/dbt_utils
+    version: ">=0.1.10"


### PR DESCRIPTION
This is very cool :)

I've only messed around with a couple of models on top of BQ sample data, essentially by rewriting [the natality example](https://cloud.google.com/bigquery-ml/docs/bigqueryml-natality).

<img width="1227" alt="Screen Shot 2020-06-11 at 8 16 22 PM" src="https://user-images.githubusercontent.com/13897643/84451232-762fda80-ac20-11ea-882f-513cd2360f69.png">

I was a bit thrown at first by reading about the [`transform` clause](https://cloud.google.com/bigquery-ml/docs/bigqueryml-transform), which BigQuery imagines one should use for feature engineering. I think that ["preprocessing"](https://cloud.google.com/bigquery-ml/docs/reference/standard-sql/bigqueryml-preprocessing-functions) should just be part of upstream model logic, and it doesn't seem like any of those functions are exclusive to the `transform` clause—so I agree with your decision (?) to exclude it from this package, but certainly curious to hear your thoughts.

### Small fixes

* The static dictionaries `_audit_table_columns` and `_audit_insert_templates` need to macros, referenced with the package namespace, called by the more complex `model_audit` and `create_model_audit_table` macros
* `dbt_ml._audit_table_columns` depends on `dbt_utils.type_timestamp()`, so I added a `packages.yml` declaring a dependency on `dbt_utils>=0.1.10`. (That's [the version](https://github.com/fishtown-analytics/dbt-utils/releases/tag/0.1.10) which added `type_timestamp`.)