### PR TITLE
Added support for AutoML, DNN and Boosted Tree models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,6 @@
 name: "dbt_ml"
-version: "0.1.0"
+version: "0.3.0"
 
-require-dbt-version: [">=0.16.0"]
+config-version: 2
+
+require-dbt-version: [">=0.17.0"]


### PR DESCRIPTION
Added support for AutoML, DNN and Boosted Tree models; require dbt v0.17.

New models are:
- AutoML regressor
- AutoML classifier
- Deep neural net regressor
- Deep neural net classifier
- Boosted tree regressor
- Boosted tree classifier

The required dbt version is bumped to v0.17, and the config-version is updated to version 2.