### PR TITLE
Add arima

### DIFF
--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -93,7 +93,7 @@ tensorflow: {}
 
 {% macro model_audit() %}
 
-    {% set model_type = config.get('ml_config')['model_type'] %}
+    {% set model_type = config.get('ml_config')['model_type'].lower() %}
     {% set model_type_repr = model_type if model_type in dbt_ml._audit_insert_templates().keys() else 'default' %}
 
     {% set info_types = ['training_info', 'feature_info', 'weights'] %}

--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -47,6 +47,16 @@ kmeans:
         - duration_ms
         - cluster_info
     feature_info: *default_feature_info
+arima:
+    training_info:
+        - training_run
+        - iteration
+        - cast(null as float64) as loss
+        - cast(null as float64) as eval_loss
+        - cast(null as float64) as learning_rate
+        - duration_ms
+        - array(select as struct null as centroid_id, cast(null as float64) as cluster_radius, null as cluster_size)
+    feature_info: *default_feature_info
 linear_reg:
     training_info: *default_training_info
     feature_info: *default_feature_info


### PR DESCRIPTION
This fix allows the use of ARIMA models in dbt_ml.  Other wise the post run hook fails with:

Unrecognized name: loss at [14:63]

Additionally, when looking for the correct training_info schema I use lower().  BigQuery case insensitive for the model_type.