### PR TITLE
Bugfix lowercase model type

### DIFF
--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -93,7 +93,7 @@ tensorflow: {}
 
 {% macro model_audit() %}
 
-    {% set model_type = config.get('ml_config')['model_type'].lower() %}
+    {% set model_type = config.get('ml_config')['model_type'].lower() if 'model_type' in config.get('ml_config').keys() else None  %}
     {% set model_type_repr = model_type if model_type in dbt_ml._audit_insert_templates().keys() else 'default' %}
 
     {% set info_types = ['training_info', 'feature_info', 'weights'] %}

--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -93,7 +93,7 @@ tensorflow: {}
 
 {% macro model_audit() %}
 
-    {% set model_type = config.get('ml_config')['model_type'].lower() if 'model_type' in config.get('ml_config').keys() else None  %}
+    {% set model_type = config.get('ml_config')['model_type'].lower() if config.get('ml_config')['model_type'] else None  %}
     {% set model_type_repr = model_type if model_type in dbt_ml._audit_insert_templates().keys() else 'default' %}
 
     {% set info_types = ['training_info', 'feature_info', 'weights'] %}


### PR DESCRIPTION
My testing on my previous PR was not exhaustive.  It turns out that for a fresh run of dbt during the compile phase, config.get('ml_config')['model_type'] returns None, so the lower() command causes a compilation error.  This fixes that issue.

I'm not actually sure why ml_config array is empty during compile.  This may cause issues elsewhere.