### PR TITLE
Rename fishtown-analytics to dbt-labs

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "dbt_ml"
-version: "0.3.0"
+version: "0.5.0"
 
 config-version: 2
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - package: fishtown-analytics/dbt_utils
+  - package: dbt-labs/dbt_utils
     version: ">=0.1.10"


### PR DESCRIPTION
Suggestion on support for rename of fishtown-analytics to dbt-labs