### PR TITLE
Added support for BQML tensorflow models, and evaluate information

### DIFF
--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -7,6 +7,7 @@
     'training_info': 'array<struct<training_run int64, iteration int64, loss float64, eval_loss float64, learning_rate float64, duration_ms int64, cluster_info array<struct<centroid_id int64, cluster_radius float64, cluster_size int64>>>>',
     'feature_info': 'array<struct<input string, min float64, max float64, mean float64, median float64, stddev float64, category_count int64, null_count int64>>',
     'weights': 'array<struct<processed_input string, weight float64, category_weights array<struct<category string, weight float64>>>>',
+    'evaluate': 'array<struct<precision	float64, recall	float64, accuracy float64, f1_score float64, log_loss float64, roc_auc float64>>',
 }) %}
 
 {% endmacro %}
@@ -25,6 +26,7 @@ default: &default
         - duration_ms
         - array(select as struct null as centroid_id, cast(null as float64) as cluster_radius, null as cluster_size)
     feature_info: &default_feature_info ['*']
+    evaluate: ['*']
 automl_classifier:
     training_info: *default_training_info
     feature_info: *default_feature_info
@@ -96,7 +98,7 @@ tensorflow: {}
     {% set model_type = config.get('ml_config')['model_type'].lower() if config.get('ml_config')['model_type'] else None  %}
     {% set model_type_repr = model_type if model_type in dbt_ml._audit_insert_templates().keys() else 'default' %}
 
-    {% set info_types = ['training_info', 'feature_info', 'weights'] %}
+    {% set info_types = ['training_info', 'feature_info', 'weights', 'evaluate'] %}
 
     insert `{{ target.database }}.{{ var('dbt_ml:audit_schema') }}.{{ var('dbt_ml:audit_table') }}`
     (model, schema, created_at, {{ info_types | join(', ') }})

--- a/macros/materializations/model.sql
+++ b/macros/materializations/model.sql
@@ -30,7 +30,7 @@
     {% set options -%}
         options(
             {%- for opt_key, opt_val in ml_config.items() -%}
-                {%- if opt_val is sequence and (opt_val | first).startswith('hparam_') -%}
+                {%- if opt_val is sequence and not (opt_val | first) is number and (opt_val | first).startswith('hparam_') -%}
                     {{ opt_key }}={{ opt_val[0] }}({{ opt_val[1:] | join(', ') }})
                 {%- else -%}
                     {{ opt_key }}={{ (opt_val | tojson) if opt_val is string else opt_val }}
@@ -69,9 +69,11 @@
         ml_config=ml_config,
         labels=raw_labels
     ) }}
+    {%- if ml_config['MODEL_TYPE'] != 'TENSORFLOW'-%}
     as (
         {{ sql }}
     );
+    {%- endif -%}
 {% endmacro %}
 
 {% materialization model, adapter='bigquery' -%}

--- a/macros/materializations/model.sql
+++ b/macros/materializations/model.sql
@@ -69,7 +69,7 @@
         ml_config=ml_config,
         labels=raw_labels
     ) }}
-    {%- if ml_config['MODEL_TYPE'] != 'TENSORFLOW'-%}
+    {%- if ml_config.get('MODEL_TYPE', ml_config.get('model_type', '')).lower() != 'tensorflow' -%}
     as (
         {{ sql }}
     );


### PR DESCRIPTION
This pull request includes a few minor changes, as follows:

- **model_audit hook:** enabled the recording of the evaluation information, which is supported by most BQML models.  The information is recorded in a new array of struct `evaluate`
- **model materialization:** 
  - resolved a bug which did not allow to pass a list of integer parameters to a model. This is required for parameters like the HIDDEN_UNITS on a DNN
  - added support for Tensorflow models, which do not require a select statement.

To test the fixed behaviour for the list of integers create a DNN model with any HIDDEN_UNITS, for example
```
{{config( 
        materialized='model',
        ml_config={ 
                    'MODEL_TYPE': 'DNN_CLASSIFIER',
                    'INPUT_LABEL_COLS': ['label'],
                    'HIDDEN_UNITS': [8, 4]
                   } 
        ) 
    }}
```

To test the support for Tensorflow models create a model as follows:
```
{{config( 
        materialized='model',
        ml_config={ 
                    'MODEL_TYPE': 'TENSORFLOW',
                    'MODEL_PATH': 'path_to_your_tf_model_in_GCS'
                   } 
        )
}}
```