### PR TITLE
Issue38: Fix for tuple startswith error

### DIFF
--- a/macros/materializations/model.sql
+++ b/macros/materializations/model.sql
@@ -30,7 +30,7 @@
     {% set options -%}
         options(
             {%- for opt_key, opt_val in ml_config.items() -%}
-                {%- if opt_val is sequence and not (opt_val | first) is number and (opt_val | first).startswith('hparam_') -%}
+                {%- if opt_val is sequence and not (opt_val | first) is number and (opt_val | first)[0].startswith('hparam_') -%}
                     {{ opt_key }}={{ opt_val[0] }}({{ opt_val[1:] | join(', ') }})
                 {%- else -%}
                     {{ opt_key }}={{ (opt_val | tojson) if opt_val is string else opt_val }}


### PR DESCRIPTION
Pull Request to fix the issue:
https://github.com/kristeligt-dagblad/dbt_ml/issues/38

The `startswith` method was called on a tuple rather than the key of the tuple. This fix changes the code to only check the key value, which contains the configuration keys for the model.

This has been tested locally and works as expected - runs without error and builds a model in BigQuery.