### PR TITLE
Fix incompatibility with dbt utils v1.0.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,4 +3,4 @@ version: "0.5.0"
 
 config-version: 2
 
-require-dbt-version: [">=0.20.0"]
+require-dbt-version: [">=1.2.0"]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "dbt_ml"
-version: "0.5.0"
+version: "0.6.0"
 
 config-version: 2
 

--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -3,7 +3,7 @@
 {% do return ({
     'model': 'string',
     'schema': 'string',
-    'created_at': dbt_utils.type_timestamp(),
+    'created_at': type_timestamp(),
     'training_info': 'array<struct<training_run int64, iteration int64, loss float64, eval_loss float64, learning_rate float64, duration_ms int64, cluster_info array<struct<centroid_id int64, cluster_radius float64, cluster_size int64>>>>',
     'feature_info': 'array<struct<input string, min float64, max float64, mean float64, median float64, stddev float64, category_count int64, null_count int64>>',
     'weights': 'array<struct<processed_input string, weight float64, category_weights array<struct<category string, weight float64>>>>',


### PR DESCRIPTION
Should fix the bug reported in: https://github.com/kristeligt-dagblad/dbt_ml/issues/40 as it's the recommended fix, but it should be checked.

Basically, the code refers to a dbt_utils macro that no longer exists in that package and is now included in dbt core itself, so needs no prefix.

You may want to support early versions of dbt without this support, in which case a try / catch is probably the way to go, but that's a choice I'm not going to advocate for or impose in this request, until requested.