### PR TITLE
Fixed model_audit.sql to allow ARIMA_PLUS model types

### DIFF
--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -59,6 +59,16 @@ arima:
         - duration_ms
         - array(select as struct null as centroid_id, cast(null as float64) as cluster_radius, null as cluster_size)
     feature_info: *default_feature_info
+arima_plus:
+    training_info:
+        - training_run
+        - iteration
+        - cast(null as float64) as loss
+        - cast(null as float64) as eval_loss
+        - cast(null as float64) as learning_rate
+        - duration_ms
+        - array(select as struct null as centroid_id, cast(null as float64) as cluster_radius, null as cluster_size)
+    feature_info: *default_feature_info
 linear_reg:
     training_info: *default_training_info
     feature_info: *default_feature_info


### PR DESCRIPTION
ARIMA is set to be deprecated so there should be an allowance to use both in the interim.

Have tested on my own dbt project for both model types, both run successfully

Addresses #47 