### PR TITLE
Patch for class_weights

### DIFF
--- a/macros/materializations/model.sql
+++ b/macros/materializations/model.sql
@@ -25,6 +25,8 @@
             {%- for opt_key, opt_val in ml_config.items() -%}
                 {%- if opt_val is sequence and (opt_val | first) is string and (opt_val | first).startswith('hparam_') -%}
                     {{ opt_key }}={{ opt_val[0] }}({{ opt_val[1:] | join(', ') }})
+                {%- elif opt_key == 'class_weights' -%}
+                    {{ opt_key }}={{ opt_val if opt_val is string else opt_val }}
                 {%- else -%}
                     {{ opt_key }}={{ (opt_val | tojson) if opt_val is string else opt_val }}
                 {%- endif -%}

--- a/macros/materializations/model.sql
+++ b/macros/materializations/model.sql
@@ -26,7 +26,7 @@
                 {%- if opt_val is sequence and (opt_val | first) is string and (opt_val | first).startswith('hparam_') -%}
                     {{ opt_key }}={{ opt_val[0] }}({{ opt_val[1:] | join(', ') }})
                 {%- elif opt_key == 'class_weights' -%}
-                    {{ opt_key }}={{ opt_val if opt_val is string else opt_val }}
+                    {{ opt_key }}={{ opt_val }}
                 {%- else -%}
                     {{ opt_key }}={{ (opt_val | tojson) if opt_val is string else opt_val }}
                 {%- endif -%}


### PR DESCRIPTION
In the ml_config, current dbt_ml code does not adequately support the 'class_weights' argument for models. This has to do with macros/materializations/model.sql line 29. The BigQuery ML specification for class weights requires an array of structs of key-value pairs to be passed in as a parameter (see [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-create-glm#class_weights)). In dbt, this needs to be passed as a string, as code will not compile with the word 'struct' and curly brace constructors are not supported. However, the current logic for string parameter handling, specifically the `| tojson` does not work with structs. This simple patch allows for the following types of class weight calls for model creation:

![Screenshot 2024-02-01 at 11 05 25 AM](https://github.com/kristeligt-dagblad/dbt_ml/assets/51249406/dfc766bf-24ef-4406-874f-78f9c6cabd19)
