### PR TITLE
Add support for connections to remote models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "dbt_ml"
-version: "0.6.0"
+version: "0.6.1"
 
 config-version: 2
 

--- a/macros/materializations/model.sql
+++ b/macros/materializations/model.sql
@@ -54,13 +54,13 @@
     {%- set ml_config = config.get('ml_config', {}) -%}
     {%- set raw_labels = config.get('labels', {}) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
-    
+
     {{ sql_header if sql_header is not none }}
 
     create or replace model {{ relation }}
 
-    {% if ml_config.get("connection_name") %}
-        remote with connection `{{ ml_config.pop("connection_name") }}`
+    {% if ml_config.get('connection_name') %}
+        remote with connection `{{ ml_config.pop('connection_name') }}`
     {% endif %}
 
     {{ dbt_ml.model_options(

--- a/macros/materializations/model.sql
+++ b/macros/materializations/model.sql
@@ -54,19 +54,13 @@
     {%- set ml_config = config.get('ml_config', {}) -%}
     {%- set raw_labels = config.get('labels', {}) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
-    {%- set has_sql = true -%}
-
-    {%- if ml_config.get('MODEL_TYPE', ml_config.get('model_type', '')).lower() == 'tensorflow' -%}
-        {%- set has_sql = false -%}
-    {%- endif -%}
-
+    
     {{ sql_header if sql_header is not none }}
 
     create or replace model {{ relation }}
 
     {% if ml_config.get("connection_name") %}
         remote with connection `{{ ml_config.pop("connection_name") }}`
-        {% set has_sql = false %}
     {% endif %}
 
     {{ dbt_ml.model_options(
@@ -74,7 +68,7 @@
         labels=raw_labels
     ) }}
 
-    {%- if has_sql -%}
+    {%- if sql -%}
         as (
             {{ sql }}
         );


### PR DESCRIPTION
Adding support for connections to remote models created with following procedure:

CREATE OR REPLACE MODEL {model_name}
REMOTE WITH CONNECTION {connection_name}
OPTIONS(ENDPOINT='{endpoint_name}' [, ...])

In the current version, as noted in #52, there's a lack of support for the class of remote models on e.g. VertexAI due to the 'remote with connection {connection_name}' line necessary for their creation juxtaposed to the ones currently supported. This update just creates an if-block looking for 'connection_name' in the ml_config object and adds the line if present.

Example usage:
{{
    config(
        materialized='model',
        ml_config={
            'connection_name': {connection_name}
            'endpoint': {endpoint_name}
        }
    )
}}



#52 