### PR TITLE
Added quality-of-life feature to make model_type lookup case-insensitive in the model_audit macro

### DIFF
--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -131,9 +131,24 @@ onnx: {}
 
 {% endmacro %}
 
+{% macro _get_model_type(ml_config) %}
+
+    {%- set ns = namespace(model_type=none) %}
+    {%- if ml_config %}
+        {%- for key, value in ml_config.items() %}
+            {%- if key.lower() == 'model_type' %}
+                {%- set ns.model_type = value | string | lower %}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+    {% do return(ns.model_type) %}
+
+{% endmacro %}
+    
 {% macro model_audit() %}
 
-    {% set model_type = config.get('ml_config')['model_type'].lower() if config.get('ml_config')['model_type'] else None  %}
+    {%- set ml_config = config.get('ml_config', {}) -%}
+    {% set model_type = dbt_ml._get_model_type(ml_config) %}
     {% set model_type_repr = model_type if model_type in dbt_ml._audit_insert_templates().keys() else 'default' %}
 
     {% set info_types = ['training_info', 'feature_info', 'weights', 'evaluate'] %}


### PR DESCRIPTION
This is a small quality of life change that makes the  lookup for the `model_type` key in the `ml_config` dictionary case insensitive.

In the `dbt_ml.model_audit` macro, I observed that the `model_type` is inferred from the `ml_config` dictionary and is used to write some template information to the model audit table in BigQuery. However, the key `'model_type'` is explicitly required to be lower case. 

This merge request primarily stems from an issue I encountered (see the discussion in #56) where if I used `"MODEL_TYPE": "ARIMA_PLUS"` in the `ml_config` dictionary I hit issues when using the post-hook:
```
models:
  <project>:
    ml:
      enabled: true
      schema: ml
      materialized: model
      post-hook: "{{ dbt_ml.model_audit() }}"
```

The case requirement is not immediately clear if one compares the `dbt_ml` syntax in the README to the [BigQuery ML syntax guide](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-create). 

There are three paths to remedy this:
- Make it clear in the README.md file that `model_type` is supposed to be lower case. 
- Use the changes to the macro contained within this merge request. 
- Accept that this is a highly unlikely issue for users to face and ignore this MR.

I do not have a preference. Please choose the path that you think is most sensible.

Please let me know if you require me to first create an issue and then link this merge request to an issue, I could not find any contribution guidelines.