### PR TITLE
Replace non-breaking spaces with regular spaces

### DIFF
--- a/macros/detect_anomalies.sql
+++ b/macros/detect_anomalies.sql
@@ -1,6 +1,6 @@
 {% macro detect_anomalies(relation, source, threshold = 0.95) %}
     ml.detect_anomalies(
-        model {{ relation }},
+        model {{ relation }},
         struct({{ threshold }} as anomaly_prob_threshold),
         (select * from {{ source }})
     )

--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -147,8 +147,8 @@ onnx: {}
         current_timestamp as created_at,
 
         {% for info_type in info_types %}
-            {% if info_type not in dbt_ml._audit_insert_templates()[model_type_repr] %}
-                cast(null as {{ dbt_ml._audit_table_columns()[info_type] }}) as {{ info_type }}
+            {% if info_type not in dbt_ml._audit_insert_templates()[model_type_repr] %}
+                cast(null as {{ dbt_ml._audit_table_columns()[info_type] }}) as {{ info_type }}
             {% else %}
                 array(
                     select as struct {{ dbt_ml._get_audit_info_cols(model_type, info_type) | join(', ') }}

--- a/macros/predict.sql
+++ b/macros/predict.sql
@@ -1,6 +1,6 @@
 {% macro predict(relation, source, threshold = none) %}
     ml.predict(
-        model {{ relation }},
+        model {{ relation }},
         (select * from {{ source }})
 
         {%- if threshold is not none -%}

--- a/macros/recommend.sql
+++ b/macros/recommend.sql
@@ -1,6 +1,6 @@
 {% macro recommend(relation, source, threshold = none) %}
     ml.recommend(
-        model {{ relation }},
+        model {{ relation }},
         (select * from {{ source }})
 
         {%- if threshold is not none -%}


### PR DESCRIPTION
Tidies up some non-breaking spaces lying around, see for example
`cat -A macros/predict.sql`