### PR TITLE
add model_options column to record training settings in string

### DIFF
--- a/macros/hooks/model_audit.sql
+++ b/macros/hooks/model_audit.sql
@@ -4,6 +4,7 @@
     'model': 'string',
     'schema': 'string',
     'created_at': type_timestamp(),
+    'model_options': 'string',
     'training_info': 'array<struct<training_run int64, iteration int64, loss float64, eval_loss float64, learning_rate float64, duration_ms int64, cluster_info array<struct<centroid_id int64, cluster_radius float64, cluster_size int64>>>>',
     'feature_info': 'array<struct<input string, min float64, max float64, mean float64, median float64, stddev float64, category_count int64, null_count int64, dimension int64>>',
     'weights': 'array<struct<processed_input string, weight float64, category_weights array<struct<category string, weight float64>>>>',
@@ -139,12 +140,33 @@ onnx: {}
     {% set info_types = ['training_info', 'feature_info', 'weights', 'evaluate'] %}
 
     insert `{{ target.database }}.{{ var('dbt_ml:audit_schema') }}.{{ var('dbt_ml:audit_table') }}`
-    (model, schema, created_at, {{ info_types | join(', ') }})
+    (model, schema, created_at, model_options, {{ info_types | join(', ') }})
 
     select
         '{{ this.table }}' as model,
         '{{ this.schema }}' as schema,
         current_timestamp as created_at,
+
+        {# Extract and store model options as JSON #}
+        (
+            select to_json_string(
+                {% if model_type is not none %}
+                (select as struct 
+                    {% for key, value in config.get('ml_config').items() %}
+                        {% if value is string %}
+                            '{{ value }}' as {{ key }}{% if not loop.last %},{% endif %}
+                        {% elif value is iterable and value is not mapping %}
+                            [{% for item in value %}'{{ item }}'{% if not loop.last %}, {% endif %}{% endfor %}] as {{ key }}{% if not loop.last %},{% endif %}
+                        {% else %}
+                            {{ value }} as {{ key }}{% if not loop.last %},{% endif %}
+                        {% endif %}
+                    {% endfor %}
+                )
+                {% else %}
+                null
+                {% endif %}
+            )
+        ) as model_options,
 
         {% for info_type in info_types %}
             {% if info_type not in dbt_ml._audit_insert_templates()[model_type_repr] %}


### PR DESCRIPTION
Adds a string column to the audit table that stores the model config eg

> {"max_iterations":20,"max_tree_depth":5,"early_stop":true,"input_label_cols":["label"],"data_split_method":"CUSTOM","data_split_col":"split_column"}

This change and #65 would break the existing audit table schema, existing tables could be updated with
```
ALTER TABLE `{{ target.database }}.{{ var('dbt_ml:audit_schema') }}.{{ var('dbt_ml:audit_table') }}`
ADD COLUMN IF NOT EXISTS model_options STRING,
ADD COLUMN IF NOT EXISTS feature_importance ARRAY<STRUCT<
    feature STRING, 
    importance_weight INT64, 
    importance_gain FLOAT64, 
    importance_coverage FLOAT64
>>;
```